### PR TITLE
Change menu option in docs to match current CLI

### DIFF
--- a/docs/basics/quickstart.md
+++ b/docs/basics/quickstart.md
@@ -91,7 +91,7 @@ Next, you'll create an Entropy account.
 You need funds to interact with the Entropy network. Your funds are stored in an account. You can have multiple accounts.
 
 1. Select **Manage Accounts**.
-1. Select **New**.
+1. Select **Create/Import Account**.
 1. Type `n` and press `ENTER` when asked _Would you like to import a key?_:
 
     ```output


### PR DESCRIPTION
When following the quickstart and cloning the cli repo, currently at commit [a5c11](https://github.com/entropyxyz/cli/commit/a5c113b5825a52b7fe547cc7a2b379adffa1e91f), the cli menu option for creating accounts differs from the quickstart guide.  This edit updates the guide to match the cli's option.