### PR TITLE
Updates testnet address and removes port numbers.

### DIFF
--- a/docs/guides/transfer-funds.md
+++ b/docs/guides/transfer-funds.md
@@ -20,7 +20,7 @@ To transfer funds, you must have the following:
 
    ![](./images/transfer-funds-import-accounts.png)
 
-1. Start the Substrate explorer and connect to the `testnet.entropy.xyz:9944` network.
+1. Start the Substrate explorer and connect to the `testnet.entropy.xyz` network.
 1. Select the **Accounts** dropdown and click **Accounts**.
 
    ![](./images/transfer-funds-accounts-dropdown.png)

--- a/docs/guides/use-the-explorer.md
+++ b/docs/guides/use-the-explorer.md
@@ -10,10 +10,6 @@ The [Polkadot\{.js\} Apps](https://polkadot.js.org/apps) is a user interface for
 
 - [Docker](https://docker.com)
 
-:::note Why Docker?
-The Entropy networks use regular WebSockets `wss://...`, rather than Secure WebSockets `wss://...`. Due to this limitation, you must run the block explorer _locally_. The easiest way to do this is to use Docker.
-:::
-
 ## Run the explorer
 
 1. Open a terminal window and run:

--- a/docs/guides/use-the-explorer.md
+++ b/docs/guides/use-the-explorer.md
@@ -11,7 +11,7 @@ The [Polkadot\{.js\} Apps](https://polkadot.js.org/apps) is a user interface for
 - [Docker](https://docker.com)
 
 :::note Why Docker?
-The Entropy networks use regular WebSockets `ws://...`, rather than Secure WebSockets `wss://...`. Due to this limitation, you must run the block explorer _locally_. The easiest way to do this is to use Docker.
+The Entropy networks use regular WebSockets `wss://...`, rather than Secure WebSockets `wss://...`. Due to this limitation, you must run the block explorer _locally_. The easiest way to do this is to use Docker.
 :::
 
 ## Run the explorer
@@ -19,7 +19,7 @@ The Entropy networks use regular WebSockets `ws://...`, rather than Secure WebSo
 1. Open a terminal window and run:
 
    ```shell
-   docker run --rm -it --name polkadot-ui -e WS_URL=ws://testnet.entropy.xyz -p 80:80 jacogr/polkadot-js-apps:latest
+   docker run --rm -it --name polkadot-ui -e WS_URL=wss://testnet.entropy.xyz -p 80:80 jacogr/polkadot-js-apps:latest
    ```
 
    This command will start a background process.
@@ -37,7 +37,7 @@ The Entropy networks use regular WebSockets `ws://...`, rather than Secure WebSo
 
    ```plaintext
    # Testnet
-   ws://testnet.entropy.xyz
+   wss://testnet.entropy.xyz
    ```
 
 1. Click the **Save** icon next to the address field.

--- a/docs/guides/use-the-explorer.md
+++ b/docs/guides/use-the-explorer.md
@@ -19,7 +19,7 @@ The Entropy networks use regular WebSockets `ws://...`, rather than Secure WebSo
 1. Open a terminal window and run:
 
    ```shell
-   docker run --rm -it --name polkadot-ui -e WS_URL=ws://testnet.entropy.xyz:9944 -p 80:80 jacogr/polkadot-js-apps:latest
+   docker run --rm -it --name polkadot-ui -e WS_URL=ws://testnet.entropy.xyz -p 80:80 jacogr/polkadot-js-apps:latest
    ```
 
    This command will start a background process.
@@ -37,7 +37,7 @@ The Entropy networks use regular WebSockets `ws://...`, rather than Secure WebSo
 
    ```plaintext
    # Testnet
-   ws://testnet.entropy.xyz:9944
+   ws://testnet.entropy.xyz
    ```
 
 1. Click the **Save** icon next to the address field.

--- a/docs/reference/rust-testing-interface.md
+++ b/docs/reference/rust-testing-interface.md
@@ -65,7 +65,7 @@ You can use the following environment variables to make using the RTI easier:
 | Variable | Description | Example |
 | -------- | ----------- | ------- |
 | `ENTROPY-MNEMONIC` | The mnemonic of the account you'd like to use when interacting with the RTI. | `ENTROPY_MNEMONIC='choice square dance because into glance hazard return cram host snap deer'` |
-| `ENTROPY_DEVNET` | The specific chain-endpoint you want to use when interacting with the RTI. | `ENTROPY_DEVNET='ws://testnet.entropy.xyz:9944'` |
+| `ENTROPY_DEVNET` | The specific chain-endpoint you want to use when interacting with the RTI. | `ENTROPY_DEVNET='ws://testnet.entropy.xyz'` |
 
 ## Usage
 
@@ -82,7 +82,7 @@ entropy-test-cli register <MNEMONIC> [KEY_VISIBILITY] [PROGRAMS]
 #### Example
 
 ```shell
-entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz:9944" register "image point raccoon steak champion clown adult until hamster sun army year"
+entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz" register "image point raccoon steak champion clown adult until hamster sun army year"
 ```
 
 ### Status
@@ -98,7 +98,7 @@ entropy-test-cli status
 #### Example
 
 ```shell
-entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz:9944" status
+entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz" status
 ```
 
 ### Sign
@@ -114,7 +114,7 @@ entropy-test-cli sign <SIGNATURE_VERIFYING_KEY> <MESSAGE> [AUXILARY_DATA]
 #### Example
 
 ```output
-entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz:9944" sign "0x1ca639d1cae8ea4e4bd37f972999e0e140866614b621bc09950ceb469b987e27" "Good morning."
+entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz" sign "0x1ca639d1cae8ea4e4bd37f972999e0e140866614b621bc09950ceb469b987e27" "Good morning."
 ```
 
 ### Store program
@@ -130,7 +130,7 @@ entropy-test-cli store-program <MNEMONIC> [PROGRAM_FILE] [CONFIG_INTERFACE_FILE]
 #### Example
 
 ```shell
-entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz:9944" store-program "image point raccoon steak champion clown adult until hamster sun army year" ./program.wasm ./interface-file.config ./aux-data.config
+entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz" store-program "image point raccoon steak champion clown adult until hamster sun army year" ./program.wasm ./interface-file.config ./aux-data.config
 ```
 
 ### Update programs
@@ -146,5 +146,5 @@ entropy-test-cli update-programs <SIGNATURE_VERIFYING_KEY> <MNEMONIC> [PROGRAMS]
 #### Example
 
 ```shell
-entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz:9944" update-programs "0x1ca639d1cae8ea4e4bd37f972999e0e140866614b621bc09950ceb469b987e27" "image point raccoon steak champion clown adult until hamster sun army year" ./programs
+entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz" update-programs "0x1ca639d1cae8ea4e4bd37f972999e0e140866614b621bc09950ceb469b987e27" "image point raccoon steak champion clown adult until hamster sun army year" ./programs
 ```

--- a/docs/reference/rust-testing-interface.md
+++ b/docs/reference/rust-testing-interface.md
@@ -65,7 +65,7 @@ You can use the following environment variables to make using the RTI easier:
 | Variable | Description | Example |
 | -------- | ----------- | ------- |
 | `ENTROPY-MNEMONIC` | The mnemonic of the account you'd like to use when interacting with the RTI. | `ENTROPY_MNEMONIC='choice square dance because into glance hazard return cram host snap deer'` |
-| `ENTROPY_DEVNET` | The specific chain-endpoint you want to use when interacting with the RTI. | `ENTROPY_DEVNET='ws://testnet.entropy.xyz'` |
+| `ENTROPY_DEVNET` | The specific chain-endpoint you want to use when interacting with the RTI. | `ENTROPY_DEVNET='wss://testnet.entropy.xyz'` |
 
 ## Usage
 
@@ -82,7 +82,7 @@ entropy-test-cli register <MNEMONIC> [KEY_VISIBILITY] [PROGRAMS]
 #### Example
 
 ```shell
-entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz" register "image point raccoon steak champion clown adult until hamster sun army year"
+entropy-test-cli --chain-endpoint="wss://testnet.entropy.xyz" register "image point raccoon steak champion clown adult until hamster sun army year"
 ```
 
 ### Status
@@ -98,7 +98,7 @@ entropy-test-cli status
 #### Example
 
 ```shell
-entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz" status
+entropy-test-cli --chain-endpoint="wss://testnet.entropy.xyz" status
 ```
 
 ### Sign
@@ -114,7 +114,7 @@ entropy-test-cli sign <SIGNATURE_VERIFYING_KEY> <MESSAGE> [AUXILARY_DATA]
 #### Example
 
 ```output
-entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz" sign "0x1ca639d1cae8ea4e4bd37f972999e0e140866614b621bc09950ceb469b987e27" "Good morning."
+entropy-test-cli --chain-endpoint="wss://testnet.entropy.xyz" sign "0x1ca639d1cae8ea4e4bd37f972999e0e140866614b621bc09950ceb469b987e27" "Good morning."
 ```
 
 ### Store program
@@ -130,7 +130,7 @@ entropy-test-cli store-program <MNEMONIC> [PROGRAM_FILE] [CONFIG_INTERFACE_FILE]
 #### Example
 
 ```shell
-entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz" store-program "image point raccoon steak champion clown adult until hamster sun army year" ./program.wasm ./interface-file.config ./aux-data.config
+entropy-test-cli --chain-endpoint="wss://testnet.entropy.xyz" store-program "image point raccoon steak champion clown adult until hamster sun army year" ./program.wasm ./interface-file.config ./aux-data.config
 ```
 
 ### Update programs
@@ -146,5 +146,5 @@ entropy-test-cli update-programs <SIGNATURE_VERIFYING_KEY> <MNEMONIC> [PROGRAMS]
 #### Example
 
 ```shell
-entropy-test-cli --chain-endpoint="ws://testnet.entropy.xyz" update-programs "0x1ca639d1cae8ea4e4bd37f972999e0e140866614b621bc09950ceb469b987e27" "image point raccoon steak champion clown adult until hamster sun army year" ./programs
+entropy-test-cli --chain-endpoint="wss://testnet.entropy.xyz" update-programs "0x1ca639d1cae8ea4e4bd37f972999e0e140866614b621bc09950ceb469b987e27" "image point raccoon steak champion clown adult until hamster sun army year" ./programs
 ```


### PR DESCRIPTION
Simply removes the port number from the testnet URLs since they won't be needed anymore, soon. Also updates address to use secure `wss`.

Set to _draft_ so that we don't accidentally merge this in too early.

Closes https://github.com/entropyxyz/entropy-docs/issues/145