### PR TITLE
Updates docs to use NPM -g install for CLI.

### DIFF
--- a/docs/basics/quickstart.md
+++ b/docs/basics/quickstart.md
@@ -18,36 +18,26 @@ The Entropy network provides threshold signing as a service. That means that mul
 
 The command-line interface (CLI) is the most straightforward way to interact with Entropy from your device.
 
-1. Ensure you have Node.js version 20.9.0 or above, and Yarn version 1.22.22 installed:
+1. Ensure you have Node.js version 20.9.0 or above:
 
     ```shell
-    node --version && yarn --version
+    node --version
     ```
 
     ```output
     v22.2.0
-    1.22.22
     ```
 
-1. Clone the Entropy CLI repository and move into the new `cli` directory:
+1. Install the Entropy CLI globally using NPM:
 
     ```shell
-    git clone https://github.com/entropyxyz/cli
-    cd cli
+    npm install --global @entropyxyz/cli
     ```
 
-1. Use Yarn to install the dependencies and build the project.
+1. Run the CLI using `entropy`:
 
     ```shell
-    yarn
-    ```
-
-    This pulls in the necessary packages and builds the CLI locally.
-
-1. Run the CLI using `yarn`:
-
-    ```shell
-    yarn start
+    entropy
     ```
 
     ```output
@@ -136,7 +126,7 @@ We're currently publically testing some of the Entropy tooling. As such, some of
 
 Once you have been sent some funds, you can check your balance in the CLI.
 
-6. Open the CLI text-based user interface using `yarn start`.
+6. Open the CLI text-based user interface using `entropy`.
 1. Select **Balance** from the menu.
 1. You should see your account in the list. Use the arrow keys to highlight it and press `ENTER`.
 1. The CLI should show your balance:

--- a/docs/guides/deploy-a-program.md
+++ b/docs/guides/deploy-a-program.md
@@ -24,7 +24,7 @@ Next, you can move on to starting the CLI and deploying your program.
 
 ### Deploy the program
 
-1. Start the CLI by running `yarn start` within your local copy of the `entropyxyz/cli` repository.
+1. Start the CLI by running `entropy`.
 1. At the main menu within the CLI, select **Deploy Program**:
 
    ```output
@@ -55,7 +55,7 @@ You can now interact with your program using the program pointer.
 
 If you've lost your program pointer, you can list it by running the following:
 
-1. Start the CLI by running `yarn start` within your local copy of the `entropyxyz/cli` repository.
+1. Start the CLI by running `entropy`.
 1. At the main menu within the CLI, select **Deploy Program**:
 
    ```output
@@ -83,4 +83,4 @@ If you've lost your program pointer, you can list it by running the following:
 
 ## Troubleshooting
 
-**No such file or directory**: this indicates that you have given the CLI a path to a `.wasm` file that either does not exist or the CLI does not have permission to read from. Confirm that the path is correct and that the CLI has permission to read from that file. An easy way to do this is to move the `.wasm` program file into the same directory from which you are running the `yarn start` command.
+**No such file or directory**: this indicates that you have given the CLI a path to a `.wasm` file that either does not exist or the CLI does not have permission to read from. Confirm that the path is correct and that the CLI has permission to read from that file.

--- a/docs/guides/manage-accounts.md
+++ b/docs/guides/manage-accounts.md
@@ -12,7 +12,7 @@ You need to have the Entropy CLI installed. [Take a look at the CLI page for det
 
 ### Create an account
 
-1. Start the CLI by running `yarn start` within your local copy of the `entropyxyz/cli` repository.
+1. Start the CLI by running `entropy`.
 1. Select **Manage Accounts**.
 1. Select **New**.
 1. Type `n` and press `ENTER` when asked _Would you like to import a key?_:
@@ -37,7 +37,7 @@ You need to have the Entropy CLI installed. [Take a look at the CLI page for det
 
 You can import an account by the `seed` for the account. Most Substrate-based wallets allow you to export your account information.
 
-1. Start the CLI by running `yarn start` within your local copy of the `entropyxyz/cli` repository.
+1. Start the CLI by running `entropy`.
 1. Select **Manage Accounts**.
 1. Select **New**.
 1. Type `y` and press `ENTER` when asked _Would you like to import a key?_:

--- a/docs/guides/register-an-account.md
+++ b/docs/guides/register-an-account.md
@@ -6,7 +6,7 @@ Registering an account is a feature unique to Entropy. Without going into too mu
 
 ## CLI
 
-1. Start the CLI by running `yarn start` within your local copy of the `entropyxyz/cli` repository.
+1. Start the CLI by running `entropy`.
 1. At the main menu within the CLI, select **Register**:
 
    ```output

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,73 +6,42 @@ In its current state, the CLI acts more like a text-based user interface (TUI). 
 
 ## Install
 
-Follow these steps to manually install the CLI.
+Follow these steps to install Entropy globally using NPM:
 
-:::tip One-line install
-Already know what you're doing and just want to get the CLI going? Run this one-liner to install the CLI's dependencies, clone the repository, build the project, and run the interface:
-
-```plaintext
-# Debian/Ubuntu
-sudo apt update -y && sudo apt install nodejs npm -y && npm install -g yarn && git clone https://github.com/entropyxyz/cli && cd cli && yarn && yarn
-```
-
-```plaintext
-# MacOS
-brew update && brew install node && source ~/.zshrc && npm install -g yarn && git clone https://github.com/entropyxyz/cli && cd cli && yarn && yarn
-```
-
-If you're new to the CLI or just want to see what each command outputs, follow the rest of this guide.
-:::
-
-1. Make sure you've got Yarn 1.22.X installed:
-
-    ```
-    # MacOS
-    brew install yarn
-    ```
+1. Ensure you have Node.js version 20.9.0 or above:
 
     ```shell
-    # Debian/Ubuntu
-    sudo apt install yarn -y
+    node --version
     ```
+
+    ```output
+    v22.2.0
+    ```
+
+1. Install the Entropy CLI globally using NPM:
 
     ```shell
-    # Arch
-    sudo pacman -S yarn
+    npm install --global @entropyxyz/cli
     ```
 
-1. Clone the Entropy CLI repository and move into the new directory:
+1. You can now run the CLI anywhere using `entropy`:
 
     ```shell
-    git clone https://github.com/entropyxyz/cli && cd cli
+    entropy
     ```
 
-1. Build the CLI with Yarn:
+    ```output
+    ? Select Action (Use arrow keys)
 
-    ```shell
-    yarn
+    ❯ Manage Accounts
+      Balance
+      Register
+      Sign
+      Transfer
+      Deploy Program
+      User Programs
+      Exit
     ```
-
-1. Start the CLI:
-
-    ```shell
-    yarn start
-    ```
-
-You should now see the main menu:
-
-```output
-? Select Action (Use arrow keys)
-
-❯ Manage Accounts
-  Balance
-  Register
-  Sign
-  Transfer
-  Deploy Program
-  User Programs
-  Exit
-```
 
 ## Functions
 
@@ -205,8 +174,6 @@ Press `CTRL` + `c` at any point to exit the CLI program, even if you're within a
 ? Select Action Transfer
 ? Input amount to transfer: 1000
 ? Input recipient's address:        <----- Pressed `CTRL` + `c` here.
-error Command failed with exit code 130.
-info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
 user@computer: $
 ```
 


### PR DESCRIPTION
The CLI can now be installed with `npm install --global @entropyxyz/cli`. This PR updates all references to the _old_ `yarn install` process, as well as some other Yarn-related house-keeping.