### PR TITLE
Simply removes the CLI installation from homepage.

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -41,47 +41,6 @@ Explore our guides and examples to integrate Entropy into your project:
 
 {{< /cards >}}
 
-## Install the CLI
-
-The Entropy command-line interface (CLI) is the fastest way to interact with the Entropy network. You can find out more by heading over to the [CLI reference section](./reference/cli.md).
-
-{{< tabs items="Debian/Ubuntu, MacOS, Build from source" >}}
-
-    {{< tab >}}
-    ```shell
-    sudo apt update -y 
-    sudo apt install nodejs npm -y
-    npm install -g yarn 
-    git clone https://github.com/entropyxyz/cli 
-    cd cli 
-    yarn 
-    yarn start
-    ```
-    {{< /tab >}}
-
-    {{< tab >}}
-    ```shell
-    brew update 
-    brew install node 
-    source ~/.zshrc 
-    npm install -g yarn 
-    git clone https://github.com/entropyxyz/cli 
-    cd cli 
-    yarn 
-    yarn start
-    ```
-    {{< /tab >}}
-
-    {{< tab >}}
-    ```shell
-    git clone https://github.com/entropyxyz/cli
-    cd cli
-    make install
-    ```
-    {{< /tab >}}
-
-{{< /tabs >}}
-
 ## Need help?
 
 Are you stuck with something and aren't sure what to do? Head over to the [Entropy Community repo](https://github.com/entropyxyz/community) for support. You can also check out the [Entropy Discord](https://discord.com/invite/9JUQwHBhVz) if you want to chat to the community!


### PR DESCRIPTION
The CLI instructions on the homepage were just there are filler. This PR removes them.