### PR TITLE
Moves callout into sentence following step.

### DIFF
--- a/content/guides/deploy-a-program.md
+++ b/content/guides/deploy-a-program.md
@@ -14,11 +14,7 @@ Before you can upload your program, you'll need the following:
 
 1. The absolute path of your program (e.g. `/home/alex/simple_signer.wasm`).
 1. The program configuration for your file as a single line of JSON. Configuration files are not mandatory, as not all programs require one.
-1. An account with enough funds to deploy your program. In early tests of the Entropy testnet it cost around `2000000000000` bits to deploy a barebones program.
-
-    :::note Non-registered account
-    It is not necessary to register your account before deploying a program.
-    :::
+1. An account with enough funds to deploy your program. In early tests of the Entropy testnet it cost around `2000000000000` bits to deploy a barebones program. It is not necessary to register your account before deploying a program.
 
 Next, you can move on to starting the CLI and deploying your program.
 


### PR DESCRIPTION
Simply moves a sentence that _was_ in a callout into a list item. The callout isn't super important and just added visual clutter.