### PR TITLE
Moves content var into a better location.

### DIFF
--- a/themes/hextra/layouts/docs/list.html
+++ b/themes/hextra/layouts/docs/list.html
@@ -8,8 +8,9 @@
             <div class="content">
                 <h1>{{ .Title }}</h1>
 
-                {{ .Content }}
                 <p class="lead italic">{{ .Params.Lead }}</p>
+
+                {{ .Content }}
 
                 <div class="hextra-cards hx-mt-4 hx-gap-4 hx-grid not-prose">
                     {{ range .Pages }}

--- a/themes/hextra/layouts/docs/list.html
+++ b/themes/hextra/layouts/docs/list.html
@@ -8,7 +8,7 @@
             <div class="content">
                 <h1>{{ .Title }}</h1>
 
-                <p class="lead italic">{{ .Params.Lead }}</p>
+                <p class="lead italic">{{ .Params.Lead | markdownify }}</p>
 
                 {{ .Content }}
 
@@ -21,9 +21,9 @@
                         </span>
                         <div class="hextra-card-subtitle hx-line-clamp-3 hx-text-sm hx-font-normal hx-text-gray-500 dark:hx-text-gray-400 hx-px-4 hx-mb-4 hx-mt-2">
                             {{ if .Params.lead }}
-                                {{ .Params.lead | truncate 200 }}
+                                {{ .Params.lead | truncate 200  | markdownify }}
                             {{ else }}
-                                {{ .Summary | truncate 200 }}
+                                {{ .Summary | truncate 200 | markdownify }}
                             {{ end }}
                         </div>
                     </a>


### PR DESCRIPTION
## Link issues

Closes https://github.com/entropyxyz/entropy-docs/issues/317
Closes https://github.com/entropyxyz/entropy-docs/issues/315

## Content updates

N/a

## Meta updates

Markdown content in `_index.md` pages now shows up after the lead text.

## Final checks

- [x] I have read and followed the `CONTRIBUTING.md` guidelines and updated the documentation (`README.md`, `CONTRIBUTING.md`, etc.) to reflect these changes.
